### PR TITLE
Update update.yaml

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -5,25 +5,66 @@ on:
     branches:
       - main
   schedule:
+    # Run daily at midnight (UTC)
     - cron: '0 0 * * *'
+  # Allow manual runs from the Actions tab
+  workflow_dispatch:
 
 jobs:
-  build-and-deploy:
+  update-readme:
+    name: Build and Deploy Dynamic README
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get current copy
-        uses: actions/checkout@main
+      - name: Check out repository
+        uses: actions/checkout@v3
         with:
-          fetch-depth: 1
-      - name: Create README
+          fetch-depth: 0  # Allows us to see all history for diff/changes checks
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'  # or whichever version you need
+
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+
+      - name: Build README
         run: |
-          cd ${GITHUB_WORKSPACE}/.update/
+          cd .update
+          go mod tidy
           go run main.go
-      - name: Deploy
+        # You might specify GOOS, GOARCH if needed
+
+      # Optional: check if the newly generated README actually changed
+      - name: Check for changes
+        id: git_diff
         run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git add .
-          git commit -am "auto: Update dynamic content"
-          git push --all -f https://${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git
+          # Save the current state (so it doesn't auto-commit everything)
+          git add --all
+          # Use diff-index to detect changes against HEAD
+          if git diff-index --quiet HEAD; then
+            echo "no_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "no_changes=false" >> $GITHUB_OUTPUT
+            # We'll commit and push in the next step if changes are found
+          fi
+
+      - name: Commit and push changes
+        if: steps.git_diff.outputs.no_changes == 'false'
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+          # Commit
+          git commit -m "auto: Update dynamic content (README) [skip ci]"
+          # Push using the token
+          git push "https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" HEAD:main
+
+      - name: Notify No Changes
+        if: steps.git_diff.outputs.no_changes == 'true'
+        run: echo "No changes detected in README. Skipping commit."


### PR DESCRIPTION
Below is an enhanced GitHub Actions workflow that:

Uses a more up-to-date checkout action (actions/checkout@v3 instead of @main). Adds a manual trigger via workflow_dispatch in addition to the scheduled and push triggers. Caches Go modules for faster builds.
Checks for changes before committing to avoid unnecessary empty commits and force pushes. Renames job steps and organizes them more clearly. Feel free to adapt any fields (e.g., the cron schedule or naming conventions) to match your specific use case.

Explanation & Improvements
on: workflow_dispatch

Lets you manually run this workflow in addition to the scheduled and push triggers. actions/checkout@v3

Replaces the older checkout@main. Also uses fetch-depth: 0 so we have the full commit history, which is especially useful when checking diffs. Caching Go Modules

The actions/cache@v3 step speeds up repeated builds by storing modules. Make sure your go.sum file exists in .update or the repository root as appropriate. Diff-Based Commit

The Check for changes step uses git diff-index --quiet HEAD to detect if any file modifications have been staged. If no changes, skip the commit; otherwise, commit and push. Skip CI in Commit

Adding [skip ci] in the commit message can prevent infinite loops if other workflows trigger on push. If you need or want that pipeline triggered, remove [skip ci]. Separated Steps

Splits logic into discrete steps for clarity: building README, checking diffs, committing/pushing, and printing a message if nothing changed. Named Job

The job is renamed to update-readme, so it’s more self-explanatory in the GitHub Actions UI. With these tweaks, the workflow is more robust, easier to maintain, and friendly for future expansions—like handling multiple files, posting Slack notifications, or automatically creating a pull request instead of committing to main.